### PR TITLE
platoengine builds trilinos without gtest; this avoids conflicts with…

### DIFF
--- a/var/spack/repos/plato/packages/platoengine/package.py
+++ b/var/spack/repos/plato/packages/platoengine/package.py
@@ -51,7 +51,7 @@ class Platoengine(CMakePackage):
     conflicts( '@0.5.0', when='+prune')
     conflicts( '@0.6.0', when='+prune')
 
-    depends_on( 'trilinos')
+    depends_on( 'trilinos~gtest')
     depends_on( 'mpi',            type=('build','link','run'))
     depends_on( 'cmake@3.0.0:',   type='build')
     depends_on( 'trilinos+rol',                               when='+rol')


### PR DESCRIPTION
Turns off gtest when building Trilinos for Platoengine. This is to be paired with a pull request in Platoengine that fixes CMakeLists files. The reason for this commit is that a double inclusion of two different gtest libraries led to strange segfaults in PE due to both libraries trying to delete allocated memory.