### PR TITLE
turned off gtest in trilinos for all PE variants

### DIFF
--- a/var/spack/repos/plato/packages/platoengine/package.py
+++ b/var/spack/repos/plato/packages/platoengine/package.py
@@ -56,9 +56,9 @@ class Platoengine(CMakePackage):
     depends_on( 'cmake@3.0.0:',   type='build')
     depends_on( 'trilinos+rol',                               when='+rol')
     depends_on( 'trilinos+zlib+pnetcdf+boost \
-                                       +stk+gtest',           when='+stk')
+                                       +stk~gtest',           when='+stk')
     depends_on( 'trilinos+percept+zoltan+zlib+pnetcdf+boost \
-                                       +stk+gtest',           when='+prune')
+                                       +stk~gtest',           when='+prune')
     depends_on( 'trilinos+zlib+pnetcdf+boost+intrepid2 \
                              +minitensor+pamgen',             when='+geometry')
     depends_on( 'googletest',                                 when='+unit_testing' )


### PR DESCRIPTION
PlatoEngine builds were failing when 'iso' was turned on since the 'iso' variant still asks for trilinos+gtest.