### PR TITLE
Update package.py

### DIFF
--- a/var/spack/repos/plato/packages/trilinos/package.py
+++ b/var/spack/repos/plato/packages/trilinos/package.py
@@ -108,7 +108,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant('isorropia',    default=False, description='Compile with Isorropia')
     variant('gtest',        default=False, description='Build vendored Googletest')
     variant('kokkos',       default=True, description='Compile with Kokkos')
-    variant('kokkoskernels',default=False, description='Compile with KokkosKernels') # required by plato team
+    variant('kokkoskernels',default=True, description='Compile with KokkosKernels') # required by plato team
     variant('ml',           default=True, description='Compile with ML')
     variant('minitensor',   default=False, description='Compile with MiniTensor')
     variant('muelu',        default=True, description='Compile with Muelu')


### PR DESCRIPTION
This seems to fix the build issue we're seeing today.  kokkoskernels was off, so tpetra and ifpack2 were getting turned off.  Turning off ifpack2 errors out.